### PR TITLE
Fix typo in spin.fish

### DIFF
--- a/functions/spin.fish
+++ b/functions/spin.fish
@@ -32,8 +32,8 @@ function spin --description 'Background job spinner'
             case n framesize
                 set size $2
 
-            case erroro
-                set errr $2
+            case error
+                set error $2
 
             case h help
                 printf "Usage: spin [OPTIONS]\n\n"


### PR DESCRIPTION
Fixes a typo that prevents the error option from working correctly